### PR TITLE
SMPP reporting

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -120,6 +120,9 @@ type Backend interface {
 
 	// RedisPool returns the redisPool for this backend
 	RedisPool() *redis.Pool
+
+	// WriteSMPPLog write the SMPP channel logs to our backend
+	WriteSMPPLog(context.Context, *SMPPLog) error
 }
 
 // NewBackend creates the type of backend passed in

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -509,6 +509,18 @@ func (b *backend) WriteChannelLogs(ctx context.Context, logs []*courier.ChannelL
 	return nil
 }
 
+// WriteSMPPLog persists the passed SMPP log to our database
+func (b *backend) WriteSMPPLog(ctx context.Context, log *courier.SMPPLog) error {
+	timeout, cancel := context.WithTimeout(ctx, backendTimeout)
+	defer cancel()
+
+	err := writeSMPPLog(timeout, b, log)
+	if err != nil {
+		logrus.WithError(err).Error("error writing channel log")
+	}
+	return nil
+}
+
 // Check if external ID has been seen in a period
 func (b *backend) CheckExternalIDSeen(msg courier.Msg) courier.Msg {
 	var prevUUID = checkExternalIDSeen(b, msg)

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -971,6 +971,21 @@ func (ts *BackendTestSuite) TestChanneLog() {
 	ts.NoError(err)
 }
 
+func (ts *BackendTestSuite) TestSMPPLog() {
+	mgaChannel := ts.getChannel("MGA", "58b70770-b76c-40e6-8755-8abb65611839")
+	ctx := context.Background()
+
+	log := courier.SMPPLog{
+		ChannelID: mgaChannel.ID(),
+		MsgID:     courier.NilMsgID,
+		Status:    courier.MsgWired,
+		CreatedOn: time.Now(),
+	}
+
+	err := writeSMPPLog(ctx, ts.b, &log)
+	ts.NoError(err)
+}
+
 func (ts *BackendTestSuite) TestWriteAttachment() {
 	ctx := context.Background()
 

--- a/backends/rapidpro/log.go
+++ b/backends/rapidpro/log.go
@@ -72,3 +72,19 @@ func writeChannelLog(ctx context.Context, b *backend, log *courier.ChannelLog) e
 	b.logCommitter.Queue(v)
 	return nil
 }
+
+const insertSMPPLogSQL = `
+INSERT INTO
+    channels_smpplog("status", "channel_id", "msg_id", "created_on")
+			  VALUES(:status,  :channel_id,  :msg_id,  :created_on)
+`
+
+func writeSMPPLog(ctx context.Context, b *backend, log *courier.SMPPLog) error {
+	rows, err := b.db.NamedQueryContext(ctx, insertSMPPLogSQL, log)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	return nil
+}

--- a/backends/rapidpro/schema.sql
+++ b/backends/rapidpro/schema.sql
@@ -135,5 +135,14 @@ CREATE TABLE msgs_messageexternalidmap
     request_logs jsonb
 );
 
+DROP TABLE IF EXISTS channels_smpplog CASCADE;
+CREATE TABLE channels_smpplog (
+     id         serial not null primary key,
+     status     character varying(1) NOT NULL,
+     created_on timestamp with time zone NOT NULL,
+     channel_id integer NOT NULL,
+     msg_id     bigint
+);
+
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO courier;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO courier;

--- a/backends/rapidpro/testdata.sql
+++ b/backends/rapidpro/testdata.sql
@@ -26,6 +26,9 @@ INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modifi
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
                       VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', NULL, 1, 'US', '', NULL);
 
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
+                      VALUES('17', '{"tel"}', 'Y', NOW(), NOW(), '58b70770-b76c-40e6-8755-8abb65611839', 'MGA', '2023', 1, 'US', 'SR', NULL);
+
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;
 INSERT INTO contacts_contact("id", "is_active", "status", "created_on", "modified_on", "uuid", "language", "ticket_count", "created_by_id", "modified_by_id", "org_id")

--- a/channel.go
+++ b/channel.go
@@ -151,6 +151,7 @@ var ErrChannelWrongType = errors.New("channel type wrong")
 
 // Channel defines the general interface backend Channel implementations must adhere to
 type Channel interface {
+	ID() ChannelID
 	UUID() ChannelUUID
 	Name() string
 	ChannelType() ChannelType

--- a/channel_log.go
+++ b/channel_log.go
@@ -114,3 +114,11 @@ type ChannelLog struct {
 	Elapsed     time.Duration `json:"elapsed"`
 	CreatedOn   time.Time     `json:"created_on"`
 }
+
+// SMPPLog represents the log for an SMPP SMS being received, sent or having its status updated.
+type SMPPLog struct {
+	ChannelID ChannelID      `json:"channel_id" db:"channel_id"`
+	MsgID     MsgID          `json:"msg_id" db:"msg_id"`
+	Status    MsgStatusValue `json:"status" db:"status"`
+	CreatedOn time.Time      `json:"created_on" db:"created_on"`
+}

--- a/handlers/mgage/empty_channel.go
+++ b/handlers/mgage/empty_channel.go
@@ -4,6 +4,7 @@ import "github.com/nyaruka/courier"
 
 type EmptyMGAChannel struct{}
 
+func (e EmptyMGAChannel) ID() courier.ChannelID                  { return courier.NilChannelID }
 func (e EmptyMGAChannel) UUID() courier.ChannelUUID              { return courier.NilChannelUUID }
 func (e EmptyMGAChannel) Name() string                           { return "" }
 func (e EmptyMGAChannel) ChannelType() courier.ChannelType       { return "MGA" }

--- a/handlers/mgage/mgage.go
+++ b/handlers/mgage/mgage.go
@@ -206,7 +206,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 			return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "no msg status, ignoring")
 		}
 		msgIDMap, err := h.Backend().GetMsgIDByExternalID(ctx, payload.MsgRef)
-		if err == sql.ErrNoRows || (msgIDMap != nil && msgIDMap.ID() == courier.NilMsgID)  {
+		if err == sql.ErrNoRows || (msgIDMap != nil && msgIDMap.ID() == courier.NilMsgID) {
 			// save channel logs if exact channel can't be defined at the moment
 			status = h.Backend().NewMsgStatusForExternalID(channel, payload.MsgRef, courier.MsgDelivered)
 			status.SetCarrierID(payload.MsgRef)

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/nyaruka/courier"
 )
@@ -51,6 +52,19 @@ func WriteMsgStatusAndResponse(ctx context.Context, h ResponseWriter, channel co
 
 	if err != nil {
 		return nil, err
+	}
+
+	if channel.ChannelType().String() == "MGA" {
+		err = h.Backend().WriteSMPPLog(ctx, &courier.SMPPLog{
+			ChannelID: status.ChannelID(),
+			MsgID:     status.ID(),
+			Status:    status.Status(),
+			CreatedOn: time.Now(),
+		})
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []courier.Event{status}, h.WriteStatusSuccessResponse(ctx, w, r, []courier.MsgStatus{status})

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -26,6 +26,16 @@ func WriteMsgsAndResponse(ctx context.Context, h ResponseWriter, msgs []courier.
 			return nil, err
 		}
 		events[i] = m
+
+		if m.Channel().ChannelType().String() == "MGA" {
+			_ = h.Backend().WriteSMPPLog(ctx, &courier.SMPPLog{
+				ChannelID: m.Channel().ID(),
+				MsgID:     m.ID(),
+				Status:    courier.MsgHandled,
+				CreatedOn: time.Now(),
+			})
+		}
+
 	}
 
 	return events, h.WriteMsgSuccessResponse(ctx, w, r, msgs)
@@ -55,16 +65,12 @@ func WriteMsgStatusAndResponse(ctx context.Context, h ResponseWriter, channel co
 	}
 
 	if channel.ChannelType().String() == "MGA" {
-		err = h.Backend().WriteSMPPLog(ctx, &courier.SMPPLog{
+		_ = h.Backend().WriteSMPPLog(ctx, &courier.SMPPLog{
 			ChannelID: status.ChannelID(),
 			MsgID:     status.ID(),
 			Status:    status.Status(),
 			CreatedOn: time.Now(),
 		})
-
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return []courier.Event{status}, h.WriteStatusSuccessResponse(ctx, w, r, []courier.MsgStatus{status})

--- a/status.go
+++ b/status.go
@@ -13,6 +13,7 @@ const (
 	MsgWired     MsgStatusValue = "W"
 	MsgEnroute   MsgStatusValue = "U"
 	MsgErrored   MsgStatusValue = "E"
+	MsgHandled   MsgStatusValue = "H"
 	MsgDelivered MsgStatusValue = "D"
 	MsgFailed    MsgStatusValue = "F"
 	NilMsgStatus MsgStatusValue = ""
@@ -26,7 +27,7 @@ const (
 type MsgStatus interface {
 	EventID() int64
 
-	ChannelID()   ChannelID
+	ChannelID() ChannelID
 	ChannelUUID() ChannelUUID
 	ID() MsgID
 
@@ -38,9 +39,9 @@ type MsgStatus interface {
 	SetExternalID(string)
 
 	// required fields for SMPP
-	GatewayID() string  // External ID from mGage for tracking MsgStatus
+	GatewayID() string // External ID from mGage for tracking MsgStatus
 	SetGatewayID(string)
-	CarrierID() string  // External ID from service behind mGage for tracking MsgStatus
+	CarrierID() string // External ID from service behind mGage for tracking MsgStatus
 	SetCarrierID(string)
 
 	Status() MsgStatusValue

--- a/test.go
+++ b/test.go
@@ -440,6 +440,7 @@ func init() {
 
 // MockChannel implements the Channel interface and is used in our tests
 type MockChannel struct {
+	id          ChannelID
 	uuid        ChannelUUID
 	channelType ChannelType
 	schemes     []string
@@ -449,6 +450,9 @@ type MockChannel struct {
 	config      map[string]interface{}
 	orgConfig   map[string]interface{}
 }
+
+// ID returns the id for this channel
+func (c *MockChannel) ID() ChannelID { return c.id }
 
 // UUID returns the uuid for this channel
 func (c *MockChannel) UUID() ChannelUUID { return c.uuid }

--- a/test.go
+++ b/test.go
@@ -187,6 +187,10 @@ func (mb *MockBackend) WriteChannelLogs(ctx context.Context, logs []*ChannelLog)
 	return nil
 }
 
+func (mb *MockBackend) WriteSMPPLog(ctx context.Context, smppLog *SMPPLog) error {
+	return nil
+}
+
 // SetErrorOnQueue is a mock method which makes the QueueMsg call throw the passed in error on next call
 func (mb *MockBackend) SetErrorOnQueue(shouldError bool) {
 	mb.errorOnQueue = shouldError

--- a/test.go
+++ b/test.go
@@ -37,6 +37,7 @@ type MockBackend struct {
 	msgStatuses     []MsgStatus
 	channelEvents   []ChannelEvent
 	channelLogs     []*ChannelLog
+	channelSMPPLogs []*SMPPLog
 	lastContactName string
 
 	sentMsgs  map[MsgID]bool
@@ -188,6 +189,11 @@ func (mb *MockBackend) WriteChannelLogs(ctx context.Context, logs []*ChannelLog)
 }
 
 func (mb *MockBackend) WriteSMPPLog(ctx context.Context, smppLog *SMPPLog) error {
+	mb.mutex.Lock()
+	defer mb.mutex.Unlock()
+
+	mb.channelSMPPLogs = append(mb.channelSMPPLogs, smppLog)
+
 	return nil
 }
 


### PR DESCRIPTION
It includes the SMPP logging functionality. For each message sent from RapidPro, we should have the statuses Wired, Sent, Enroute, and Delivered (or Failed), and for each message received on RapidPro from mGage, we should have the status Handled. It follows the same msg status as we have on Msg models, but it's an independent table for SMPP since we want to track every step of the msgs going through.

Ref.: https://communityconnectlabs.atlassian.net/jira/software/projects/CD/boards/3?selectedIssue=CD-106